### PR TITLE
new method to add new radix node

### DIFF
--- a/src/roe_teer/roeteer.py
+++ b/src/roe_teer/roeteer.py
@@ -3,15 +3,20 @@ from typing import TypeVar, List, Tuple, Dict
 
 T = TypeVar('T')
 
+
 class Roeteer:
     def __init__(self) -> None:
         self._radix: Dict[str, Node[T]] = {}
 
     def _get_radix(self, method: str) -> Node[T]:
-        if method not in self._radix:
-            self._radix[method] = Node[T]()
         return self._radix[method]
 
+    def _add_radix(self, method: str) -> None | Node:
+        """adds new radix tree to store"""
+        n: None | Node = None
+        if method not in self._radix:
+            n = self._radix[method] = Node[T]()
+        return n
 
     def use(self, path: str, handler: T) -> None:
         if '*' in path:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,12 +1,19 @@
 import pytest
 from roe_teer.n import Node, Result, Param
+from roe_teer.roeteer import Roeteer
 
 n = Node()
+t = Roeteer()
 
 
 @pytest.fixture
 def node():
     return n
+
+
+@pytest.fixture
+def root():
+    return t
 
 
 def test_node(node):
@@ -52,3 +59,13 @@ def test_node_dynamic_param_id_regex_lookup_success(node):
 def test_node_dynamic_param_id_regex_lookup_not_found(node):
     result = node.lookup("/test/test")
     assert result is None
+
+
+def test_add_new_radix_with_different_method_creates_node(root):
+    result = root._add_radix("<method>")
+    assert isinstance(result, Node)
+
+
+def test_add_new_radix_with_different_method_exists(root):
+    result = root._get_radix("<method>")
+    assert result is not None and isinstance(result, Node)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,5 +1,6 @@
 import pytest
 from roe_teer.n import Node, Result, Param
+
 n = Node()
 
 
@@ -33,7 +34,8 @@ def test_node_dynamic_param_lookup(node):
     """check if node is able to find handler and return dynamic params"""
     result = node.lookup("/here_param")
     assert isinstance(result, Result) and result.handler == ["Handler p"] and isinstance(
-        result.params, dict) and isinstance(result.params.get("param"), Param) and result.params.get("param").value == "here_param"
+        result.params, dict) and isinstance(result.params.get("param"), Param) and result.params.get(
+        "param").value == "here_param"
 
 
 def test_node_dynamic_param_id_regex_insert(node):
@@ -47,6 +49,6 @@ def test_node_dynamic_param_id_regex_lookup_success(node):
         result.params, dict) and isinstance(result.params.get("id"), Param) and result.params.get("id").value == "123"
 
 
-def test_node_dynamic_param_id_regex_lookup_notfound(node):
+def test_node_dynamic_param_id_regex_lookup_not_found(node):
     result = node.lookup("/test/test")
     assert result is None


### PR DESCRIPTION
**Primary change**
created new method to create radix nodes as mentioned in #1.
Ex:
```py
r = Roeteer()
r._add_radix("method")
```

**Other changes**
`Roeteer._get_radix` will now throw an error if the method doesnt exist.


Closes #1 